### PR TITLE
Prevent ResizeObserver loop limit error

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "ember-cli-babel": "^7.20.5",
     "ember-cli-htmlbars": "^5.1.2",
-    "ember-on-resize-modifier": "^0.1.1"
+    "ember-on-resize-modifier": "^0.2.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",

--- a/tests/integration/components/resize-observer-test.js
+++ b/tests/integration/components/resize-observer-test.js
@@ -348,6 +348,18 @@ module('Integration | Component | resize-observer', function (hooks) {
     assert.dom('[data-test-dimensions]').hasText('100 100 1');
   });
 
+  test('prevents ResizeObserver loop limit related errors', async function (assert) {
+    assert.expect(0);
+
+    await render(hbs`
+      <ResizeObserver as |RO|>
+        {{if RO.width "Trigger ResizeObserver again"}}
+      </ResizeObserver>
+    `);
+
+    await delay();
+  });
+
   module('matchers validation errors', function (hooks) {
     hooks.afterEach(function () {
       resetOnerror();

--- a/yarn.lock
+++ b/yarn.lock
@@ -4780,15 +4780,15 @@ ember-modifier@^1.0.3:
     ember-cli-string-utils "^1.1.0"
     ember-modifier-manager-polyfill "^1.2.0"
 
-ember-on-resize-modifier@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/ember-on-resize-modifier/-/ember-on-resize-modifier-0.1.1.tgz#7b41f407b21bad7c3a00e60bb8309880c7a97afa"
-  integrity sha512-PVBHWFAc7YX3p1ZcC1NR4sXg4BIxSOoGlujzzU7wPqlzWwmh5j768yDFMcyMLhWQaPcVnHx6ka2qID2f2ere1w==
+ember-on-resize-modifier@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/ember-on-resize-modifier/-/ember-on-resize-modifier-0.2.0.tgz#204a413eaf0ae121ca6ac2a66674434108020e34"
+  integrity sha512-bQLTgULbGN+tEiRr9GMXtaQ/KfPySJtumh86TkkgAbYAyNV3Mg1lBXymwH3I7pCRse0/vo52t77Zyvbtm9g9pQ==
   dependencies:
     ember-cli-babel "^7.20.5"
     ember-cli-htmlbars "^5.1.2"
     ember-modifier "^1.0.3"
-    ember-resize-observer-service "^0.1.0"
+    ember-resize-observer-service "^0.2.0"
 
 ember-qunit@^4.6.0:
   version "4.6.0"
@@ -4803,10 +4803,10 @@ ember-qunit@^4.6.0:
     ember-cli-test-loader "^2.2.0"
     qunit "^2.9.3"
 
-ember-resize-observer-service@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/ember-resize-observer-service/-/ember-resize-observer-service-0.1.0.tgz#d38fd409ee2f285b865de2c2c620cfd1d42b6f34"
-  integrity sha512-9CNsh1+ExLYfdVlgIZS9MdWglfI180KWezlRRqemtH4KNVCP60BVAQV6F8clDjfBpnrZbGWKkZ0kZccxpft3kQ==
+ember-resize-observer-service@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/ember-resize-observer-service/-/ember-resize-observer-service-0.2.0.tgz#28bb61fa9a85a49851a5e67920a927100ff43e5d"
+  integrity sha512-LKmc5hv1UHDyX+U/bI3pk+NMjuJD/dLqL4R51G3LSlYTHTJn6Y0Cs0c9g3j6vK5BBDDJGi6mTGqFM/dRXKkRpQ==
   dependencies:
     ember-cli-babel "^7.20.5"
     ember-cli-htmlbars "^5.1.2"


### PR DESCRIPTION
It happens when you trigger `ResizeObserver` observation in the same animation frame again. The `ResizeObserver` loop protection will move the observation to the next frame and fire an error event `ResizeObserver loop limit exceeded`. The error can be safely ignored, though it can still fail tests and make noise in Sentry logs.

An example:

```hbs
<ResizeObserver as |RO|>
  {{if RO.width "Trigger ResizeObserver just after the initial observation"}}
</ResizeObserver>
```

Related to: https://github.com/PrecisionNutrition/ember-on-resize-modifier/pull/1